### PR TITLE
Refactor hook actions

### DIFF
--- a/BIP158.md
+++ b/BIP158.md
@@ -1,0 +1,3 @@
+```
+=b158 -build-file %/lib/bip158/hoon
+```

--- a/BIP158.md
+++ b/BIP158.md
@@ -1,3 +1,5 @@
 ```
 =b158 -build-file %/lib/bip158/hoon
 ```
+
+0x31d6.6d51.6a9e.da7d.e865.df29.f6ef.6cb8.e4bf.9309.e5da.c899.968a.9a62.a5df.61e3

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -3,21 +3,21 @@
 ## Set Credentials, Ping Servers, Check Addresses and TXs
 ```
 :btc-provider|command [%set-credentials api-url='http://localhost:50002']
-:btc-provider|action ['blockfee' %ping ~]
+:btc-provider|action [%ping ~]
 
-:btc-provider|action ['addr0' %address-info [%bech32 'bc1qm7cegwfd0pvv9ypvz5nhstage00xkxevtrpshc']]
-:btc-provider|action ['addr1' %address-info [%bech32 'bc1qlwd7mw33uea5m8r2lsnsrkc7gp2qynrxsfxpfm']]
-:btc-provider|action ['addr2' %address-info [%bech32 'bc1qglkc9zfcn04vcc88nn0ljtxcpu5uxfznc3829k']]
+:btc-provider|action [%address-info [%bech32 'bc1qm7cegwfd0pvv9ypvz5nhstage00xkxevtrpshc']]
+:btc-provider|action [%address-info [%bech32 'bc1qlwd7mw33uea5m8r2lsnsrkc7gp2qynrxsfxpfm']]
+:btc-provider|action [%address-info [%bech32 'bc1qglkc9zfcn04vcc88nn0ljtxcpu5uxfznc3829k']]
 ::  first is an address w balance
 ::  second has no balance but is used
 ::  third is unused
 
-:btc-provider|action ['reqid' %raw-tx [%32 0x33f.693f.df99.5a5e.a7fe.5c95.1ab6.858c.7e6a.5fff.c585.7992.2cd4.fc31.9c61.4c5b]]
-:btc-provider|action ['reqid' %raw-tx [%32 0x2131.b660.7f25.0d31.d8da.9818.d2d9.2560.c7d6.7fe7.8ca4.0d02.6408.c090.6868.71e6]]
+:btc-provider|action [%raw-tx [%32 0x33f.693f.df99.5a5e.a7fe.5c95.1ab6.858c.7e6a.5fff.c585.7992.2cd4.fc31.9c61.4c5b]]
+:btc-provider|action [%raw-tx [%32 0x2131.b660.7f25.0d31.d8da.9818.d2d9.2560.c7d6.7fe7.8ca4.0d02.6408.c090.6868.71e6]]
 ::  first is a 382 byte tx
 ::  second is a 27.660 byte tx
 
-:btc-provider|action ['reqid' %tx-info [%32 0x9ece.9c56.9ab3.27db.ada5.a51e.2653.7b3f.7e99.5579.c18a.af4f.8620.304b.ce53.16f1]]
+:btc-provider|action [%tx-info [%32 0x9ece.9c56.9ab3.27db.ada5.a51e.2653.7b3f.7e99.5579.c18a.af4f.8620.304b.ce53.16f1]]
 ::  4 inputs, one output
 ```
 
@@ -28,20 +28,12 @@
 ::  should be %.n for included
 ```
 
-##  Generate a Raw TX from Inputs/Outputs
-```
-:btc-provider|command [%set-credentials api-url='http://localhost:50002']
-=inputs ~[[[%32 0xe86.8771.b3bf.f789.525e.21ba.c735.e280.70d1.eff0.fb4d.f59a.dc98.e914.8e2f.85d4] 0]]
-=outputs ~[[[%bech32 'bc1q0ydcskwye4rqky4qankhl4kegajl8nh50plmx0'] 12.500.000]]
-
-:btc-provider|action ['rawtx0' %create-raw-tx inputs outputs]
-```
-
 ## Send a Stale TX
 Should get an RPC error
 ```
 :btc-provider|command [%set-credentials api-url='http://localhost:50002']
-=old-tx [191 0x1.0000.0000.0101.bee9.55e9.5966.c35c.9b4f.1b9b.59b8.d84b.6104.4b1b.6c5d.5c38.0c3b.6ed8.938c.1d6d.0000.0000.00ff.ffff.ff01.385c.b010.0000.0000.1600.14ea.13bc.0f69.262d.7ab1.cb30.7668.1054.7375.4b23.bc02.4730.4402.204c.0a3c.2aed.0d4f.c7b6.e9b7.0cc9.bd0e.489a.a825.4741.9ba7.a209.e555.2d66.59e2.7402.2015.8043.b25a.7342.cc23.1b15.eb39.217b.29de.cc7d.3ca5.5953.f47a.0461.b3eb.0255.b201.2102.b791.e56d.195e.0b59.7c84.d351.9531.76a2.5501.9dd5.d0ad.8b62.10fa.590d.20f4.5b4c.0000.0000]
+=tx [191 0x1.0000.0000.0101.bee9.55e9.5966.c35c.9b4f.1b9b.59b8.d84b.6104.4b1b.6c5d.5c38.0c3b.6ed8.938c.1d6d.0000.0000.00ff.ffff.ff01.385c.b010.0000.0000.1600.14ea.13bc.0f69.262d.7ab1.cb30.7668.1054.7375.4b23.bc02.4730.4402.204c.0a3c.2aed.0d4f.c7b6.e9b7.0cc9.bd0e.489a.a825.4741.9ba7.a209.e555.2d66.59e2.7402.2015.8043.b25a.7342.cc23.1b15.eb39.217b.29de.cc7d.3ca5.5953.f47a.0461.b3eb.0255.b201.2102.b791.e56d.195e.0b59.7c84.d351.9531.76a2.5501.9dd5.d0ad.8b62.10fa.590d.20f4.5b4c.0000.0000]
 
-:btc-provider|action ['broadcast-tx' %broadcast-tx old-tx]
+:btc-provider|action [%broadcast-tx tx]
 ```
+Should show that it's `included`.

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -21,6 +21,13 @@
 ::  4 inputs, one output
 ```
 
+## TX Info for Non-Existent TX
+```
+
+:btc-provider|action ['reqid' %tx-info [%32 0x63a.bc87.c9e6.9f8f.4a76.d838.abc0.fd77.082f.9716.09a0.0b18.b45b.d3ab.793c.82df]]
+::  should be %.n for included
+```
+
 ##  Generate a Raw TX from Inputs/Outputs
 ```
 :btc-provider|command [%set-credentials api-url='http://localhost:50002']

--- a/WALLET.scratch.md
+++ b/WALLET.scratch.md
@@ -104,7 +104,7 @@ on `~dopzod`:
 ### request address
 on `~dopzod`:
 ```
-:btc-wallet-hook|action [%req-pay-address payee=~zod value=2.000 [~ 10]]
+:btc-wallet-hook|action [%req-pay-address payee=~zod value=2.000 [~ 30]]
 :btc-wallet-hook +dbug [%state 'poym']
 ```
 

--- a/WALLET.scratch.md
+++ b/WALLET.scratch.md
@@ -99,6 +99,7 @@ Provider is `~zod`, `~dopzod` is a client.  Use the xpub from PRIVATE.md to have
 On `~zod`:
 ```
 |commit %home
+
 |start %btc-provider
 |start %btc-wallet-store
 |start %btc-wallet-hook
@@ -116,6 +117,7 @@ on `~dopzod`:
 ::  xpub from PRIVATE.md
 
 |commit %home
+
 |start %btc-wallet-store
 |start %btc-wallet-hook
 :btc-wallet-hook|action [%set-provider ~zod]

--- a/WALLET.scratch.md
+++ b/WALLET.scratch.md
@@ -53,31 +53,6 @@ Mnemonic
 abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about
 ```
 
-### DEPRECATED manual scanning of empty wallet
-SEE Address Generation instead
-Uses `btc-wallet-hook`, with max-gap=3
-```
-:btc-provider|command [%set-credentials api-url='http://localhost:50002']
-:btc-wallet-hook|action [%set-provider ~zod]
-=scan-xpub 'zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs'
-=fprint [%4 0xdead.beef]
-:btc-wallet-store|action [%add-wallet scan-xpub fprint ~ [~ 3] [~ 6]]
-:btc-wallet-store +dbug
-:: shows scans with the xpub and {0 1 2} todos
-
-::  %0 account has no used
-=btc -build-file %/lib/btc/hoon
-:btc-wallet-store|action [%address-info scan-xpub %0 1 *(set utxo:btc) used=%.n 655000]
-:btc-wallet-store|action [%address-info scan-xpub %0 2 *(set utxo:btc) used=%.n 655000]
-:btc-wallet-store|action [%address-info scan-xpub %0 0 *(set utxo:btc) used=%.n 655000]
-::  dbug should give empty for scans: [xpub %0]
-:btc-wallet-store|action [%address-info scan-xpub %1 2 *(set utxo:btc) used=%.n 655000]
-:btc-wallet-store|action [%address-info scan-xpub %1 0 *(set utxo:btc) used=%.n 655000]
-:btc-wallet-store|action [%address-info scan-xpub %1 1 *(set utxo:btc) used=%.y 655000]
-:: dbug should show re-filled scans: [xpub %1]
-```
-
-
 ## Address Generation Integration Test
 All on `~zod`:
 ```
@@ -133,6 +108,18 @@ on `~dopzod`:
 :btc-wallet-hook +dbug [%state 'poym']
 ```
 
+Sign the tx, then paste:
+```
+=tx TXHEX
+:btc-wallet-hook|action [%broadcast-tx tx]
+```
+
+### Send Transaction
+
+Check wallet store
+```
+:btc-wallet-store +dbug [%state 'history']
+```
 
 ## scrys
 ```

--- a/WALLET.scratch.md
+++ b/WALLET.scratch.md
@@ -125,6 +125,6 @@ Check wallet store
 ```
 .^((list @t) %gx /=btc-wallet-store=/scanned/noun)
 
-.^(@ud %gx /=btc-wallet-store=/balance/[xpub]/noun)
+.^(@ud %gx /=btc-wallet-store=/balance/[xpubp]/noun)
 ```
 

--- a/app/btc-provider.hoon
+++ b/app/btc-provider.hoon
@@ -133,7 +133,7 @@
 ::
 ++  rpc-wire
   |=  act=action  ^-  wire
-  /[-.act]/[(scot %da now.bowl)]
+  /[-.act]/[(scot %ux (cut 3 [0 20] eny.bowl))]
 ::
 ::  Handles HTTP responses from RPC servers. Parses for errors, then handles response. 
 ::  For actions that require collating multiple RPC calls, uses req-card to call out
@@ -232,9 +232,10 @@
 ::
 ++  do-ping
   ^-  (list card)
+  =/  act=action  [%ping ~]
   :~  :*  %pass  /ping/[(scot %da now.bowl)]  %agent
           [our.bowl %btc-provider]  %poke
-          %btc-provider-action  !>([%blank-id %ping ~])
+          %btc-provider-action  !>(act)
       ==
       (start-ping-timer ~s30)
   ==

--- a/app/btc-provider.hoon
+++ b/app/btc-provider.hoon
@@ -101,22 +101,22 @@
 ++  handle-action
   |=  act=action
   ^-  (quip card _state)
-  ?.  ?|(connected.host-info =(-.body.act %ping))
+  ?.  ?|(connected.host-info =(-.act %ping))
     ~&  >>>  "Not connected to RPC"
     [~[(send-update [%| %not-connected 500])] state]
   =/  ract=action:rpc-types
-    ?-  -.body.act
+    ?-  -.act
         %address-info
-      [%get-address-info address.body.act]
+      [%get-address-info address.act]
       ::
         %tx-info
-      [%get-tx-vals txid.body.act]
+      [%get-tx-vals txid.act]
       ::
         %raw-tx
-      [%get-raw-tx txid.body.act]
+      [%get-raw-tx txid.act]
       ::
         %broadcast-tx
-      [%broadcast-tx rawtx.body.act]
+      [%broadcast-tx rawtx.act]
       ::
         %ping
       [%get-block-and-fee ~]
@@ -129,15 +129,12 @@
   =/  req=request:http
     (gen-request host-info ract)
   [%pass (rpc-wire act) %arvo %i %request req out]
-::  wire structure: /action-tas/req-id/now 
+::  wire structure: /action-tas/now
 ::
 ++  rpc-wire
   |=  act=action  ^-  wire
-  /[-.body.act]/[req-id.act]/[(scot %da now.bowl)]
+  /[-.act]/[(scot %da now.bowl)]
 ::
-++  get-req-id
-  |=  =wire  ^-  req-id
-  +<.wire
 ::  Handles HTTP responses from RPC servers. Parses for errors, then handles response. 
 ::  For actions that require collating multiple RPC calls, uses req-card to call out
 ::    to RPC again if more information is required.
@@ -178,28 +175,28 @@
 ++  handle-rpc-result
   |=  [=wire r=result:rpc-types]
   ^-  (quip card _state)
-  ?+  wire  ~|("Unexpected HTTP response" !!)
-      [%address-info @ *]
+  ?+  -.wire  ~|("Unexpected HTTP response" !!)
+      %address-info
     ?>  ?=([%get-address-info *] r)
     :_  state
-    ~[(send-update [%.y (get-req-id wire) %address-info +.r])]
+    ~[(send-update [%.y %address-info +.r])]
     ::
-      [%tx-info @ *]
+      %tx-info
     ?>  ?=([%get-tx-vals *] r)
     :_  state
-    ~[(send-update [%.y (get-req-id wire) %tx-info +.r])]
+    ~[(send-update [%.y %tx-info +.r])]
     ::
-      [%raw-tx @ *]
+      %raw-tx
     ?>  ?=([%get-raw-tx *] r)
     :_  state
-    ~[(send-update [%.y (get-req-id wire) %raw-tx +.r])] 
+    ~[(send-update [%.y %raw-tx +.r])] 
     ::
-      [%broadcast-tx @ *]
+      %broadcast-tx
     ?>  ?=([%broadcast-tx *] r)
     :_  state
-    ~[(send-update [%.y (get-req-id wire) %broadcast-tx +.r])]
+    ~[(send-update [%.y %broadcast-tx +.r])]
     ::
-      [%ping @ *]
+      %ping
     ?>  ?=([%get-block-and-fee *] r)
     :-  ~[(send-status [%connected block.r fee.r])]
     state(connected.host-info %.y)
@@ -214,9 +211,9 @@
   ^-  card
   =+  c=[%give %fact ~[/clients] %btc-provider-update !>(update)]
   ?:  ?=(%.y -.update)
-    ~&  >>  "prov. update: {<body.p.update>}"
+    ~&  >>  "prov. update: {<p.update>}"
     c
-  ~&   >>  "prov. err: {<p.update>}" 
+  ~&   >>  "prov. err: {<p.update>}"
   c
 ::
 ++  is-whitelisted

--- a/app/btc-wallet-hook.hoon
+++ b/app/btc-wallet-hook.hoon
@@ -288,6 +288,7 @@
     ==
     ::
     ::  %txinfo
+    ::  - TODO: handle case where tx is blank
     ::  - insert into wallet-store history if pend-piym or poym matches txid
     ::  - forward tx to wallet-store regardless
     ::

--- a/app/btc-wallet-hook.hoon
+++ b/app/btc-wallet-hook.hoon
@@ -437,9 +437,6 @@
 ++  poym-to-history
   |=  ti=info:tx
   |^  ^-  (quip card _state)
-  :: TODO: delete prints
-  ~&  >  "poym: {<poym>}"
-  ~&  >>>  "txid: {<txid.ti>}"
   ?~  poym  `state
   ?~  sitx.u.poym  `state
   ?.  (poym-has-txid txid.ti)
@@ -447,7 +444,6 @@
   =+  vout=(get-vout txos.u.poym)
   ?~  vout  ~|("poym-to-history: poym should always have an output" !!)
   :_  state(poym ~)
-  ~&  >>>  "poym: adding history"
   ~[(add-history-entry ti xpub.u.poym our.bowl payee.u.poym u.vout)]
   ::
   ++  get-vout

--- a/app/btc-wallet-hook.hoon
+++ b/app/btc-wallet-hook.hoon
@@ -172,6 +172,8 @@
     =+  signed=(to-rawtx:bp txhex.act)
     =/  tx-match=?
       ?~  poym  %.n
+      ~&  >>  (get-id:txu (decode:txu signed))
+      ~&  >>>  ~(get-txid txb:bwsl u.poym)
       =((get-id:txu (decode:txu signed)) ~(get-txid txb:bwsl u.poym))
     :_  ?.  tx-match  state
         ?~  poym  state
@@ -204,6 +206,11 @@
     ~[(send-update [%sign-tx u.poym])]
     ::
       %close-pym
+    ::  TODO: print out that results of the bools
+    ~&  >>>  "%close-pym: in pend-piym?"
+    ~&  >>>  (~(has by pend-piym) txid.ti.act)
+    ~&  >>>  "%close-pym: in pend-poym?"
+    ~&  >>>  (poym-has-txid txid.ti.act)
     ?>  =(src.bowl our.bowl)
     =^  cards  state
       ?.  included.ti.act
@@ -280,7 +287,8 @@
     ::  - request tx-info from provider
     ::
       %expect-payment
-    |^  =+  pay=(~(get by ps.piym) src.bowl)
+    |^
+    =+  pay=(~(get by ps.piym) src.bowl)
     ~|  "%expect-payment: matching payment not in piym"
     ?~  pay  !!
     ?>  (piym-matches u.pay)
@@ -439,6 +447,7 @@
   |^  ^-  (quip card _state)
   :: TODO: delete prints
   ~&  >  "poym: {<poym>}"
+  ~&  >>>  "txid: {<txid.ti>}"
   ?~  poym  `state
   ?~  sitx.u.poym  `state
   ?.  (poym-has-txid txid.ti)
@@ -469,12 +478,10 @@
   |=  ti=info:tx
   |^  ^-  (quip card _state)
   =+  pay=(~(get by pend-piym) txid.ti)
-  ~&  >  "piym-to-history pay: {<pay>}"
   ?~  pay  `state
   ::  if no matching output in piym, delete from pend-piym to stop DDOS of txids
   ::
   =+  vout=(get-vout value.u.pay)
-  ~&  >  "piym-to-history vout: {<vout>}"
   ?~  vout
     `(del-pend-piym txid.ti)
   :_  (del-all-piym txid.ti payer.u.pay)
@@ -488,8 +495,6 @@
     =|  idx=@ud
     =+  os=outputs.ti
     |-  ?~  os  ~
-    ~&  >>>  "vout idx: {<idx>}"
-    ~&  >>>  "vout loop value: {<value.i.os>}"
     ?:  =(value.i.os value)
       `idx
     $(os t.os, idx +(idx))

--- a/app/btc-wallet-hook.hoon
+++ b/app/btc-wallet-hook.hoon
@@ -227,6 +227,7 @@
         ==
     ?~  prov  ~
     :-  (poke-provider host.u.prov [%tx-info txid.act])
+    ?~  poym          ~
     ?~  payee.u.poym  ~
     :_  ~
     %-  poke-hook
@@ -281,7 +282,7 @@
     ?>  (piym-matches u.pay)
     :_  (update-pend-piym txid.act u.pay(pend `txid.act))
     ?~  prov  ~
-    ~[(poke-provider host.u.prov [%txinfo txid.act])]
+    ~[(poke-provider host.u.prov [%tx-info txid.act])]
     ::
     ++  piym-matches
       |=  p=payment
@@ -334,8 +335,11 @@
   ?.  ?=(%.y -.upd)  `state
   ?-  -.p.upd
       %address-info
+    =+  r=(~(get by reqs) address.p.upd)
     :_  state(reqs (~(del by reqs) address.p.upd))
-    ~[(poke-store p.upd)]
+    ?~  r  ~
+    ?>  ?=(%address-info -.u.r)
+    ~[(poke-store [%address-info xpub.u.r chyg.u.r idx.u.r +>.p.upd])]
     ::
       %tx-info
     :_  state(reqs (~(del by reqs) txid.info.p.upd))
@@ -572,7 +576,7 @@
   ^-  (list card)
   ?~  prov  ~|("provider not set" !!)
   %+  turn  ~(tap in ~(key by pend-piym))
-  |=(=txid (poke-provider host.u.prov [%txinfo txid]))
+  |=(=txid (poke-provider host.u.prov [%tx-info txid]))
 ::
 ++  get-raw-tx
   |=  [host=ship =txid]

--- a/app/btc-wallet-hook.hoon
+++ b/app/btc-wallet-hook.hoon
@@ -172,8 +172,6 @@
     =+  signed=(to-rawtx:bp txhex.act)
     =/  tx-match=?
       ?~  poym  %.n
-      ~&  >>  (get-id:txu (decode:txu signed))
-      ~&  >>>  ~(get-txid txb:bwsl u.poym)
       =((get-id:txu (decode:txu signed)) ~(get-txid txb:bwsl u.poym))
     :_  ?.  tx-match  state
         ?~  poym  state
@@ -206,11 +204,6 @@
     ~[(send-update [%sign-tx u.poym])]
     ::
       %close-pym
-    ::  TODO: print out that results of the bools
-    ~&  >>>  "%close-pym: in pend-piym?"
-    ~&  >>>  (~(has by pend-piym) txid.ti.act)
-    ~&  >>>  "%close-pym: in pend-poym?"
-    ~&  >>>  (poym-has-txid txid.ti.act)
     ?>  =(src.bowl our.bowl)
     =^  cards  state
       ?.  included.ti.act
@@ -232,9 +225,8 @@
       %succeed-broadcast-tx
     ?>  =(src.bowl our.bowl)
     ~&  >  "%succeed-broadcast-tx"
-    :_  %=  state
-          poym  ~
-          reqs  (~(put by reqs) txid.act [%tx-info 0 txid.act])
+    :_  %_  state
+            reqs  (~(put by reqs) txid.act [%tx-info 0 txid.act])
         ==
     ?~  prov  ~
     :-  (poke-provider host.u.prov [%tx-info txid.act])

--- a/app/btc-wallet-store.hoon
+++ b/app/btc-wallet-store.hoon
@@ -182,6 +182,12 @@
     ::  - add the hest
     ::  - send a tx-info request out
     `state
+    ::
+      %del-history-entry
+    ::  - delete txid from history
+    ::  - send a tx-info request out in case it gets added
+    ::
+    `state
   ==
 ::  wallet scan algorithm:
 ::  Initiate a batch for each chyg, with max-gap idxs in it

--- a/lib/bip158.hoon
+++ b/lib/bip158.hoon
@@ -1,0 +1,40 @@
+|%
++$  bits  [wid=@ dat=@ub]
+++  params
+  |%
+  ++  p  19
+  --
+::  +stre: bit streams
+::   read/write are from/to the front
+::
+++  stre
+  |%
+  ++  read-bit
+    |=  s=bits
+    ^-  [bit=@ub rest=bits]
+    ?>  (gth wid.s 0)
+    :*  ?:((gth wid.s (met 0 dat.s)) 0b0 0b1)
+        [(dec wid.s) (end [0 (dec wid.s)] dat.s)]
+    ==
+  ::
+  ++  write-bit
+    |=  [s=bits bit=@ub]
+    ^-  bits
+    ?>  (lte (met 0 bit) 1)
+    [+(wid.s) (can 0 ~[s [1 bit]])]
+  --
+::  +gol: Golomb-Rice encoding/decoding
+::
+++  gol
+  |%
+  ++  en
+    |=  b=byts
+    ^-  @ux
+    0x0
+  ::
+  ++  de
+    |=  s=bits
+    ^-  [hash=byts rest=bits]
+    [*byts *bits]
+  --
+--

--- a/lib/bip158.hoon
+++ b/lib/bip158.hoon
@@ -4,10 +4,10 @@
   |%
   ++  p  19
   --
-::  +stre: bit streams
-::   read/write are from/to the front
+::  +str: bit streams
+::   read/write are from/to the front (big-endian)
 ::
-++  stre
+++  str
   |%
   ++  read-bit
     |=  s=bits
@@ -16,6 +16,15 @@
     :*  ?:((gth wid.s (met 0 dat.s)) 0b0 0b1)
         [(dec wid.s) (end [0 (dec wid.s)] dat.s)]
     ==
+  ::
+  ++  read-bits
+    |=  [n=@ s=bits]
+    ^-  [bits rest=bits]
+    =|  bs=bits
+    |-
+    ?:  =(n 0)  [bs s]
+    =^  b  s  (read-bit s)
+    $(n (dec n), bs (write-bit s b))
   ::
   ++  write-bit
     |=  [s=bits bit=@ub]
@@ -33,8 +42,22 @@
     0x0
   ::
   ++  de
-    |=  s=bits
-    ^-  [hash=byts rest=bits]
-    [*byts *bits]
+    |=  [s=bits p=@]
+    |^
+    ^-  [delta=@ rest=bits]
+    ?>  (gth wid.s 0)
+    =^  q  s  (get-q s)
+    =^  r  s  (read-bits:str p s)
+    [(add dat.r (lsh [0 p] q)) s]
+    ::
+    ++  get-q
+      |=  s=bits
+      =|  q=@
+      =^  first-bit  s  (read-bit:str s)
+      |-
+      ?:  =(0 first-bit)  [q s]
+      =^  b  s  (read-bit:str s)
+      $(first-bit b, q +(q))
+    --
   --
 --

--- a/lib/btc-provider.hoon
+++ b/lib/btc-provider.hoon
@@ -32,7 +32,6 @@
   ^-  (unit @da)
   ?:  =(0 secs)  ~
   [~ (add ~1970.1.1 `@dr`(mul secs ~s1))]
-
 ::
 ++  to-hex
   |=  h=@t
@@ -48,6 +47,11 @@
   ::
   `@ux`(rash - hex)
 ::
+++  to-rawtx
+  |=  h=@t
+  ^-  rawtx
+  =+  bs=(to-hex h)
+  [(div (lent (trip h)) 2) bs]
 ++  to-hash256
   |=  h=@t
   (hash256 [32 (to-hex h)])

--- a/lib/btc-provider.hoon
+++ b/lib/btc-provider.hoon
@@ -109,7 +109,8 @@
     ==
     ++  address-info
       %-  ot:dejs:format
-      :~  [%utxos (as:dejs:format utxo)]
+      :~  [%address (cu:dejs:format address-from-cord so:dejs:format)]
+          [%utxos (as:dejs:format utxo)]
           [%used bo:dejs:format]
           [%block ni:dejs:format]
       ==

--- a/lib/btc-provider.hoon
+++ b/lib/btc-provider.hoon
@@ -102,7 +102,7 @@
       ::
         %get-raw-tx
       [id.res (raw-tx res.res)]
-      :: 
+      ::
         %broadcast-tx
       [%broadcast-tx (broadcast-tx res.res)]
       ::
@@ -126,9 +126,10 @@
           [%value ni:dejs:format]
           [%recvd (cu:dejs:format from-epoch ni:dejs:format)]
       ==
-    ++  tx-vals
+    ++  tx-vals 
       %-  ot:dejs:format
-      :~  [%txid (cu:dejs:format to-hash256 so:dejs:format)]
+      :~  [%included bo:dejs:format]
+          [%txid (cu:dejs:format to-hash256 so:dejs:format)]
           [%confs ni:dejs:format]
           [%recvd (cu:dejs:format from-epoch ni:dejs:format)]
           [%inputs (ar:dejs:format tx-val)]

--- a/lib/btc-provider.hoon
+++ b/lib/btc-provider.hoon
@@ -4,11 +4,6 @@
 =<  [sur .]
 =,  sur
 |%
-++  gen-req-id
-  |=  eny=@uvJ  ^-  req-id
-  %+  scot  %ux
-  (ripemd-160:ripemd:crypto [(met 3 eny) eny])
-::
 ++  address-to-cord
   |=  =address  ^-  cord
   ?:  ?=([%legacy *] address)

--- a/lib/btc-wallet-store.hoon
+++ b/lib/btc-wallet-store.hoon
@@ -58,9 +58,7 @@
           %+  turn  txis.t
           |=(=txi value.utxo.txi)
         add
-    %+  roll
-      (turn txos.t |=(=txo value.txo))
-    add
+    (roll (turn txos.t |=(=txo value.txo)) add)
   ::
   ++  tx-data
     |^  ^-  data:tx:btc
@@ -265,6 +263,7 @@
     ^-  [tb=(unit txbu) chng=(unit sats)]
     =+  tb=select-utxos
     ?~  tb  [~ ~]
+    ~&  >>>  tb
     =+  fee=~(fee txb u.tb)
     =/  costs=sats                      ::  cost of this tx + sending another
       %+  add  min-tx-fee
@@ -300,12 +299,15 @@
     =/  rng  ~(. og eny)
     =/  target  (add target-value (mul feyb (base-weight n-txos)))   ::  add base fees to target
     =|  [select=(list insel) total=sats:btc]
-    |-  ?:  =(~ is)  ~
+    |-
+    ?:  =(~ is)  ~
     =^  n  rng  (rads:rng (lent is))
     =/  i=insel  (snag n is)
+    ?.  (spendable utxo.i)
+      $(is (oust [n 1] is))
     =/  net-val  (net-value value.utxo.i)
-    =?  select  ?&((spendable utxo.i) (gth net-val 0))
-      [i select]                                           ::  select if net-value > 0
+    =?  select  (gth net-val 0)
+      [i select]
     =/  new-total  (add total net-val)
     ?:  (gte new-total target)  `select
     %=  $

--- a/lib/btc-wallet-store.hoon
+++ b/lib/btc-wallet-store.hoon
@@ -263,7 +263,6 @@
     ^-  [tb=(unit txbu) chng=(unit sats)]
     =+  tb=select-utxos
     ?~  tb  [~ ~]
-    ~&  >>>  tb
     =+  fee=~(fee txb u.tb)
     =/  costs=sats                      ::  cost of this tx + sending another
       %+  add  min-tx-fee

--- a/psbt_sign.js
+++ b/psbt_sign.js
@@ -1,8 +1,9 @@
 /*
 Usage:
-var = require("./psbt_sign.js")
+var p = require("./psbt_sign.js")
 const psbt = PSBT_STRING_BASE64
 const mnemonics = MNEMONICS_STRING
+const [psbt, mnemonics] = []
 p.run(mnemonics, psbt)
   */
 

--- a/sur/btc-provider.hoon
+++ b/sur/btc-provider.hoon
@@ -32,7 +32,7 @@
   $%  [%connected block=@ud fee=@ud]
       [%disconnected ~]
   ==
-:: 
+::
 ++  rpc-types
   |%
   +$  action

--- a/sur/btc-provider.hoon
+++ b/sur/btc-provider.hoon
@@ -13,7 +13,7 @@
       [%ping ~]
   ==
 +$  result
-  $%  [%address-info utxos=(set utxo) used=? block=@ud]
+  $%  [%address-info =address utxos=(set utxo) used=? block=@ud]
       [%tx-info =info:tx]
       [%raw-tx =txid =rawtx]
       [%broadcast-tx =txid broadcast=? included=?]
@@ -33,7 +33,7 @@
 ++  rpc-types
   |%
   +$  action
-  $%  [%get-address-info =address]
+    $%  [%get-address-info =address]
         [%get-tx-vals =txid]
         [%get-raw-tx =txid]
         [%broadcast-tx =rawtx]
@@ -42,7 +42,7 @@
     ==
   ::
   +$  result
-    $%  [%get-address-info utxos=(set utxo) used=? block=@ud]
+    $%  [%get-address-info =address utxos=(set utxo) used=? block=@ud]
         [%get-tx-vals =info:tx]
         [%get-raw-tx =txid =rawtx]
         [%create-raw-tx =rawtx]

--- a/sur/btc-provider.hoon
+++ b/sur/btc-provider.hoon
@@ -1,21 +1,18 @@
 /-  *btc
 |%
 +$  host-info  [api-url=@t connected=? clients=(set ship)]
-+$  req-id  @t
 +$  command
   $%  [%set-credentials api-url=@t]
       [%whitelist-clients clients=(set ship)]
   ==
-+$  action  [=req-id body=action-body]
-+$  action-body
++$  action
   $%  [%address-info =address]
       [%tx-info =txid]
       [%raw-tx =txid]
       [%broadcast-tx =rawtx]
       [%ping ~]
   ==
-+$  result  [=req-id body=result-body]
-+$  result-body
++$  result
   $%  [%address-info utxos=(set utxo) used=? block=@ud]
       [%tx-info =info:tx]
       [%raw-tx =txid =rawtx]

--- a/sur/btc-wallet-hook.hoon
+++ b/sur/btc-wallet-hook.hoon
@@ -29,16 +29,29 @@
 ::    - vout-n is the index of the output that has value
 ::
 +$  action
+  $%  settings
+      local
+      peer
+  ==
++$  settings
   $%  [%set-provider provider=ship]
       [%set-default-wallet ~]
-      [%req-pay-address payee=ship value=sats feyb=(unit sats)]
-      [%gen-pay-address value=sats]
-      [%ret-pay-address =address payer=ship value=sats]
-      [%broadcast-tx signed=rawtx]
-      [%expect-payment =txid value=sats]
       [%clear-poym ~]
       [%force-retry ~]
   ==
++$  local
+  $%  [%req-pay-address payee=ship value=sats feyb=(unit sats)]
+      [%broadcast-tx signed=rawtx]
+      [%poym-add-txi]
+      [%poym-to-history]
+  ==
++$  peer
+  $%  [%gen-pay-address value=sats]
+      [%ret-pay-address =address payer=ship value=sats]
+      [%expect-payment =txid value=sats]
+  ==
+::
+::
 +$  update
   $%  request
       error

--- a/sur/btc-wallet-hook.hoon
+++ b/sur/btc-wallet-hook.hoon
@@ -1,10 +1,8 @@
 /-  *btc, bws=btc-wallet-store, bp=btc-provider
 |%
 ::  btc-state: state from the provider; t is last update time
-::  req-id: hash of [xpub chyg idx]
-::  reqs: lookup of req-id -> requests from wallet-store+blockcount
-::    blockcount included so that we only request address info when
-::    there's a newer block, in the case of addresses we are cooking
+::  reqs: last block checked for an address/tx request to provider.
+::   Used to determine whether to retry request
 ::
 ::  payment: a payment expected from another ship
 ::    - address: address generated for this payment
@@ -13,8 +11,9 @@
 ::  pend-piym: incoming payment txs that peer says they have broadcast
 ::  poym: outgoing payments. One at a time: new replaces old
 ::
-+$  btc-state  [block=@ud fee=sats t=@da]
-+$  reqs  (map req-id:bp req=request:bws)
++$  block  @ud
++$  btc-state  [=block fee=sats t=@da]
++$  reqs  (map $?(address txid) request:bws)
 ::
 +$  payment  [pend=(unit txid) =xpub =address payer=ship value=sats]
 +$  piym  [ps=(map ship payment) num-fam=(map ship @ud)]
@@ -46,9 +45,8 @@
       [%add-poym =txbu:bws]
       [%add-poym-txi =txid =rawtx]
       [%close-pym ti=info:tx]
-      :: from %broadcast-tx
-      [%fail-broadcast-tx =txid]  ::  clear poym; remove from wallet-history?
-      [%succeed-broadcast-tx =txid]  :: p
+      [%fail-broadcast-tx =txid]
+      [%succeed-broadcast-tx =txid]
   ==
 +$  peer
   $%  [%gen-pay-address value=sats]

--- a/sur/btc-wallet-hook.hoon
+++ b/sur/btc-wallet-hook.hoon
@@ -40,7 +40,7 @@
   ==
 +$  local
   $%  [%req-pay-address payee=ship value=sats feyb=(unit sats)]
-      [%broadcast-tx signed=rawtx]
+      [%broadcast-tx txhex=cord] 
       [%add-piym =xpub =address payer=ship value=sats]
       [%add-poym =txbu:bws]
       [%add-poym-txi =txid =rawtx]

--- a/sur/btc-wallet-hook.hoon
+++ b/sur/btc-wallet-hook.hoon
@@ -40,7 +40,7 @@
   ==
 +$  local
   $%  [%req-pay-address payee=ship value=sats feyb=(unit sats)]
-      [%broadcast-tx txhex=cord] 
+      [%broadcast-tx txhex=cord]
       [%add-piym =xpub =address payer=ship value=sats]
       [%add-poym =txbu:bws]
       [%add-poym-txi =txid =rawtx]

--- a/sur/btc-wallet-hook.hoon
+++ b/sur/btc-wallet-hook.hoon
@@ -42,15 +42,10 @@
 +$  local
   $%  [%req-pay-address payee=ship value=sats feyb=(unit sats)]
       [%broadcast-tx signed=rawtx]
-      :: from wallet-store %generate-address
       [%add-piym =xpub =address payer=ship value=sats]
-      :: wallet-store %generate-txbu
       [%add-poym =txbu:bws]
-      ::  from %raw-tx
-      [%add-poym-txi =rawtx]
-      :: from %tx-info
-      [%finish-piym =info:tx]
-      [%finish-poym =info:tx]
+      [%add-poym-txi =txid =rawtx]
+      [%close-pym ti=info:tx]
       :: from %broadcast-tx
       [%fail-broadcast-tx =txid]  ::  clear poym; remove from wallet-history?
       [%succeed-broadcast-tx =txid]  :: p

--- a/sur/btc-wallet-hook.hoon
+++ b/sur/btc-wallet-hook.hoon
@@ -42,8 +42,18 @@
 +$  local
   $%  [%req-pay-address payee=ship value=sats feyb=(unit sats)]
       [%broadcast-tx signed=rawtx]
-      [%poym-add-txi]
-      [%poym-to-history]
+      :: from wallet-store %generate-address
+      [%add-piym =xpub =address payer=ship value=sats]
+      :: wallet-store %generate-txbu
+      [%add-poym =txbu:bws]
+      ::  from %raw-tx
+      [%add-poym-txi =rawtx]
+      :: from %tx-info
+      [%finish-piym =info:tx]
+      [%finish-poym =info:tx]
+      :: from %broadcast-tx
+      [%fail-broadcast-tx =txid]  ::  clear poym; remove from wallet-history?
+      [%succeed-broadcast-tx =txid]  :: p
   ==
 +$  peer
   $%  [%gen-pay-address value=sats]

--- a/sur/btc-wallet-store.hoon
+++ b/sur/btc-wallet-store.hoon
@@ -94,6 +94,7 @@
       [%generate-address =xpub =chyg =peta]
       [%generate-txbu =xpub payee=(unit ship) feyb=sats txos=(list txo)]
       [%add-history-entry =hest]
+      [%del-history-entry =txid]
   ==
 ::
 +$  update

--- a/sur/btc-wallet-store.hoon
+++ b/sur/btc-wallet-store.hoon
@@ -89,7 +89,7 @@
 ::
 +$  action
   $%  [%add-wallet =xpub =fprint scan-to=(unit scon) max-gap=(unit @ud) confs=(unit @ud)]
-      [%address-info =xpub =chyg =idx utxos=(set utxo) used=? block=@ud]
+      [%address-info =address utxos=(set utxo) used=? block=@ud]
       [%tx-info =info:tx block=@ud]
       [%generate-address =xpub =chyg =pmet]
       [%generate-txbu =xpub payee=(unit ship) feyb=sats txos=(list txo)]
@@ -106,7 +106,7 @@
 ::  last-block: most recent block this address was checked
 ::
 +$  request
-  $%  [%address-info last-block=@ud a=address =xpub =chyg =idx]
+  $%  [%address-info last-block=@ud a=address]
       [%tx-info last-block=@ud =txid]
   ==
 --

--- a/sur/btc-wallet-store.hoon
+++ b/sur/btc-wallet-store.hoon
@@ -40,7 +40,7 @@
       confs=@ud
   ==
 ::  insel: a selected utxo for input to a transaction
-::  peta: optional payment metadata
+::  pmet: optional payment metadata
 ::  feyb: fee per byte in sats
 ::  txi/txo:  input/output for a transaction being built
 ::   - txo has an hdkey if it's a change account
@@ -49,7 +49,7 @@
 ::   - sitx: signed hex transaction
 ::
 +$  insel  [=utxo =chyg =idx]
-+$  peta  (unit [payer=ship value=sats])
++$  pmet  (unit [payer=ship value=sats])
 +$  feyb  sats
 +$  txi  [=utxo ur=(unit rawtx) =hdkey]
 +$  txo  [=address value=sats hk=(unit hdkey)]
@@ -91,14 +91,14 @@
   $%  [%add-wallet =xpub =fprint scan-to=(unit scon) max-gap=(unit @ud) confs=(unit @ud)]
       [%address-info =xpub =chyg =idx utxos=(set utxo) used=? block=@ud]
       [%tx-info =info:tx block=@ud]
-      [%generate-address =xpub =chyg =peta]
+      [%generate-address =xpub =chyg =pmet]
       [%generate-txbu =xpub payee=(unit ship) feyb=sats txos=(list txo)]
       [%add-history-entry =hest]
       [%del-history-entry =txid]
   ==
 ::
 +$  update
-  $%  [%generate-address =xpub =address =peta]
+  $%  [%generate-address =xpub =address =pmet]
       [%generate-txbu =xpub =txbu]
       [%saw-piym s=ship =txid]
       [%scan-done =xpub]

--- a/sur/btc-wallet-store.hoon
+++ b/sur/btc-wallet-store.hoon
@@ -107,6 +107,6 @@
 ::
 +$  request
   $%  [%address-info last-block=@ud a=address =xpub =chyg =idx]
-      [%tx-info last-block=@ud =txidtxid]
+      [%tx-info last-block=@ud =txid]
   ==
 --

--- a/sur/btc-wallet-store.hoon
+++ b/sur/btc-wallet-store.hoon
@@ -89,7 +89,7 @@
 ::
 +$  action
   $%  [%add-wallet =xpub =fprint scan-to=(unit scon) max-gap=(unit @ud) confs=(unit @ud)]
-      [%address-info =address utxos=(set utxo) used=? block=@ud]
+      [%address-info =xpub =chyg =idx utxos=(set utxo) used=? block=@ud]
       [%tx-info =info:tx block=@ud]
       [%generate-address =xpub =chyg =pmet]
       [%generate-txbu =xpub payee=(unit ship) feyb=sats txos=(list txo)]
@@ -106,7 +106,7 @@
 ::  last-block: most recent block this address was checked
 ::
 +$  request
-  $%  [%address-info last-block=@ud a=address]
+  $%  [%address-info last-block=@ud a=address =xpub =chyg =idx]
       [%tx-info last-block=@ud =txid]
   ==
 --

--- a/sur/btc-wallet-store.hoon
+++ b/sur/btc-wallet-store.hoon
@@ -107,6 +107,6 @@
 ::
 +$  request
   $%  [%address-info last-block=@ud a=address =xpub =chyg =idx]
-      [%tx-info last-block=@ud =txid]
+      [%tx-info last-block=@ud =txidtxid]
   ==
 --

--- a/sur/btc.hoon
+++ b/sur/btc.hoon
@@ -42,8 +42,11 @@
         =address
         value=sats
     ==
+  ::  included: whether tx is in the mempool or blockchain
+  ::
   +$  info
-    $:  =txid
+    $:  included=?
+        =txid
         confs=@ud
         recvd=(unit @da)
         inputs=(list val)


### PR DESCRIPTION
Instead of doing everything when provider or wallet-store send updates, we now feed an action back into the wallet-hook for more clarity.